### PR TITLE
Refactor to BLoC architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Chat StartKit
 
-A modern Flutter chat application built with Clean Architecture and Riverpod.
+A modern Flutter chat application built with Clean Architecture and the BLoC pattern.
 
 ## 🚀 Features
 
 - Clean Architecture pattern
-- Riverpod for state management
+- BLoC for state management
 - GoRouter for navigation
 - Dio for network requests
 - Dark/Light theme support

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,7 +15,7 @@ It guides future contributors (humans + AI) with consistent context and reasonin
 - **Framework**: Flutter (latest stable)
 - **Language**: Dart
 - **Architecture Pattern**: Clean Architecture (presentation / domain / data)
-- **State Management**: Riverpod (can swap to Provider, Bloc)
+- **State Management**: BLoC
 - **Routing**: `go_router`
 - **Tests**: Unit, Widget, Integration (`flutter_test`, `mocktail`)
 

--- a/src/lib/bloc/message_bloc.dart
+++ b/src/lib/bloc/message_bloc.dart
@@ -1,0 +1,60 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+
+import '../models/message.dart';
+import '../services/local_storage_service.dart';
+import '../services/websocket_service.dart';
+
+part 'message_event.dart';
+part 'message_state.dart';
+
+class MessageBloc extends Bloc<MessageEvent, MessageState> {
+  final WebSocketService socketService;
+  final LocalStorageService storageService;
+  StreamSubscription<Message>? _socketSub;
+
+  MessageBloc({required this.socketService, required this.storageService})
+      : super(const MessageState()) {
+    on<LoadMessages>(_onLoad);
+    on<SendMessage>(_onSend);
+    on<_ReceivedMessage>(_onReceived);
+    on<_ErrorReceived>(_onError);
+  }
+
+  Future<void> _onLoad(LoadMessages event, Emitter<MessageState> emit) async {
+    final cached = await storageService.getCachedMessages();
+    emit(state.copyWith(messages: cached));
+    await socketService.connect();
+    _socketSub = socketService.messages.listen(
+      (message) => add(_ReceivedMessage(message)),
+      onError: (error) => add(_ErrorReceived(error.toString())),
+    );
+  }
+
+  Future<void> _onSend(SendMessage event, Emitter<MessageState> emit) async {
+    socketService.send(event.message);
+    final updated = List<Message>.from(state.messages)..add(event.message);
+    await storageService.cacheMessages(updated);
+    emit(state.copyWith(messages: updated));
+  }
+
+  Future<void> _onReceived(
+      _ReceivedMessage event, Emitter<MessageState> emit) async {
+    final updated = List<Message>.from(state.messages)..add(event.message);
+    await storageService.cacheMessages(updated);
+    emit(state.copyWith(messages: updated));
+  }
+
+  Future<void> _onError(_ErrorReceived event, Emitter<MessageState> emit) async {
+    emit(state.copyWith(error: event.error));
+  }
+
+  @override
+  Future<void> close() {
+    _socketSub?.cancel();
+    socketService.disconnect();
+    return super.close();
+  }
+}

--- a/src/lib/bloc/message_event.dart
+++ b/src/lib/bloc/message_event.dart
@@ -1,0 +1,36 @@
+part of 'message_bloc.dart';
+
+abstract class MessageEvent extends Equatable {
+  const MessageEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class LoadMessages extends MessageEvent {
+  const LoadMessages();
+}
+
+class SendMessage extends MessageEvent {
+  final Message message;
+  const SendMessage(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}
+
+class _ReceivedMessage extends MessageEvent {
+  final Message message;
+  const _ReceivedMessage(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}
+
+class _ErrorReceived extends MessageEvent {
+  final String error;
+  const _ErrorReceived(this.error);
+
+  @override
+  List<Object?> get props => [error];
+}

--- a/src/lib/bloc/message_state.dart
+++ b/src/lib/bloc/message_state.dart
@@ -1,0 +1,18 @@
+part of 'message_bloc.dart';
+
+class MessageState extends Equatable {
+  final List<Message> messages;
+  final String? error;
+
+  const MessageState({this.messages = const [], this.error});
+
+  MessageState copyWith({List<Message>? messages, String? error}) {
+    return MessageState(
+      messages: messages ?? this.messages,
+      error: error,
+    );
+  }
+
+  @override
+  List<Object?> get props => [messages, error];
+}

--- a/src/lib/main.dart
+++ b/src/lib/main.dart
@@ -1,4 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'bloc/message_bloc.dart';
+import 'screens/home_screen.dart';
+import 'services/local_storage_service.dart';
+import 'services/websocket_service.dart';
 
 void main() {
   runApp(const MyApp());
@@ -9,55 +15,25 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter 多平台應用',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
-        useMaterial3: true,
-      ),
-      home: const MyHomePage(),
-    );
-  }
-}
+    final socketService = WebSocketService('wss://example.com/ws');
+    final storageService = LocalStorageService();
 
-class MyHomePage extends StatelessWidget {
-  const MyHomePage({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text('Flutter 多平台示範'),
-      ),
-      body: const Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              Icons.flutter_dash,
-              size: 100,
-              color: Colors.blue,
-            ),
-            SizedBox(height: 20),
-            Text(
-              '歡迎使用 Flutter！',
-              style: TextStyle(
-                fontSize: 24,
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-            SizedBox(height: 10),
-            Text(
-              '這是一個支援 iOS、Android 和 Web 的應用程式',
-              textAlign: TextAlign.center,
-              style: TextStyle(
-                fontSize: 16,
-                color: Colors.grey,
-              ),
-            ),
-          ],
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider(
+          create: (_) => MessageBloc(
+            socketService: socketService,
+            storageService: storageService,
+          ),
         ),
+      ],
+      child: MaterialApp(
+        title: 'Flutter Chat',
+        theme: ThemeData(
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+          useMaterial3: true,
+        ),
+        home: const HomeScreen(),
       ),
     );
   }

--- a/src/lib/models/message.dart
+++ b/src/lib/models/message.dart
@@ -1,0 +1,31 @@
+import 'dart:convert';
+
+class Message {
+  final String id;
+  final String content;
+  final DateTime timestamp;
+
+  Message({required this.id, required this.content, required this.timestamp});
+
+  factory Message.fromJson(Map<String, dynamic> json) {
+    return Message(
+      id: json['id'] as String,
+      content: json['content'] as String,
+      timestamp: DateTime.parse(json['timestamp'] as String),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'content': content,
+        'timestamp': timestamp.toIso8601String(),
+      };
+
+  static String encodeList(List<Message> messages) =>
+      json.encode(messages.map((m) => m.toJson()).toList());
+
+  static List<Message> decodeList(String source) =>
+      (json.decode(source) as List)
+          .map((e) => Message.fromJson(e as Map<String, dynamic>))
+          .toList();
+}

--- a/src/lib/screens/home_screen.dart
+++ b/src/lib/screens/home_screen.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../bloc/message_bloc.dart';
+import '../models/message.dart';
+
+class HomeScreen extends StatefulWidget {
+  const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  final _controller = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    context.read<MessageBloc>().add(const LoadMessages());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final brand = const String.fromEnvironment('BRAND', defaultValue: 'Default');
+    final tenant = const String.fromEnvironment('TENANT', defaultValue: 'Main');
+
+    return Scaffold(
+      appBar: AppBar(title: Text('Chat - $brand/$tenant')),
+      body: Column(
+        children: [
+          Expanded(
+            child: BlocBuilder<MessageBloc, MessageState>(
+              builder: (context, state) {
+                if (state.messages.isEmpty) {
+                  return const Center(child: Text('No messages'));
+                }
+                return ListView.builder(
+                  itemCount: state.messages.length,
+                  itemBuilder: (context, index) {
+                    final message = state.messages[index];
+                    return ListTile(
+                      title: Text(message.content),
+                      subtitle: Text(message.timestamp.toIso8601String()),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _controller,
+                    decoration: const InputDecoration(hintText: 'Message'),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.send),
+                  onPressed: () {
+                    final text = _controller.text;
+                    if (text.isNotEmpty) {
+                      final message = Message(
+                        id: DateTime.now().millisecondsSinceEpoch.toString(),
+                        content: text,
+                        timestamp: DateTime.now(),
+                      );
+                      context.read<MessageBloc>().add(SendMessage(message));
+                      _controller.clear();
+                    }
+                  },
+                )
+              ],
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/src/lib/services/encryption_service.dart
+++ b/src/lib/services/encryption_service.dart
@@ -1,0 +1,17 @@
+import 'dart:convert';
+import 'package:crypto/crypto.dart';
+
+class EncryptionService {
+  // This is only a demo. In production, store keys securely.
+  static const _key = 'temporary-key';
+
+  static String encrypt(String input) {
+    final bytes = utf8.encode('$_key$input');
+    return base64Encode(bytes);
+  }
+
+  static String decrypt(String input) {
+    final decoded = utf8.decode(base64Decode(input));
+    return decoded.replaceFirst('$_key', '');
+  }
+}

--- a/src/lib/services/local_storage_service.dart
+++ b/src/lib/services/local_storage_service.dart
@@ -1,0 +1,19 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/message.dart';
+
+class LocalStorageService {
+  static const _messagesKey = 'cached_messages';
+
+  Future<void> cacheMessages(List<Message> messages) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_messagesKey, Message.encodeList(messages));
+  }
+
+  Future<List<Message>> getCachedMessages() async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = prefs.getString(_messagesKey);
+    if (data == null) return [];
+    return Message.decodeList(data);
+  }
+}

--- a/src/lib/services/websocket_service.dart
+++ b/src/lib/services/websocket_service.dart
@@ -1,0 +1,46 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import '../models/message.dart';
+import 'encryption_service.dart';
+
+class WebSocketService {
+  final String url;
+  WebSocketChannel? _channel;
+  final _controller = StreamController<Message>.broadcast();
+
+  Stream<Message> get messages => _controller.stream;
+
+  WebSocketService(this.url);
+
+  Future<void> connect() async {
+    _channel = WebSocketChannel.connect(Uri.parse(url));
+    _channel!.stream.listen((data) {
+      final decrypted = EncryptionService.decrypt(data as String);
+      final jsonMap = json.decode(decrypted) as Map<String, dynamic>;
+      _controller.add(Message.fromJson(jsonMap));
+    }, onError: (error) {
+      _controller.addError(error);
+      reconnect();
+    }, onDone: () {
+      reconnect();
+    });
+  }
+
+  void send(Message message) {
+    final encrypted = EncryptionService.encrypt(json.encode(message.toJson()));
+    _channel?.sink.add(encrypted);
+  }
+
+  Future<void> disconnect() async {
+    await _channel?.sink.close();
+    await _controller.close();
+  }
+
+  Future<void> reconnect() async {
+    await Future.delayed(const Duration(seconds: 2));
+    await connect();
+  }
+}

--- a/src/pubspec.yaml
+++ b/src/pubspec.yaml
@@ -31,6 +31,13 @@ dependencies:
   flutter:
     sdk: flutter
 
+  flutter_bloc: ^8.1.3
+  equatable: ^2.0.5
+  web_socket_channel: ^2.4.0
+  shared_preferences: ^2.2.0
+  crypto: ^3.0.3
+  flutter_secure_storage: ^9.0.0
+
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8


### PR DESCRIPTION
## Summary
- restructure code under `src/lib` into BLoC architecture
- add services for WebSocket, local storage and simple encryption
- implement `MessageBloc` with events and states
- create a `HomeScreen` widget using BLoC
- expose brand/tenant via `dart-define`
- update documentation to mention BLoC

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart format -o none --set-exit-if-changed src/lib` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431ee950a0832fb00d34b916729771