### PR TITLE
Add unit tests

### DIFF
--- a/docs/TASK.md
+++ b/docs/TASK.md
@@ -16,6 +16,7 @@ It's used by both human developers and AI agents.
 - [ ] Setup `BottomNavigationBar` with 3 tabs
 - [ ] Implement banner carousel on HomePage
 - [ ] Connect navigation state with content rendering
+- [x] Add basic unit tests for Message model and EncryptionService (2025-06-06)
 
 ---
 

--- a/src/test/encryption_service_test.dart
+++ b/src/test/encryption_service_test.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:chat_startkit_flutter/services/encryption_service.dart';
+
+void main() {
+  test('encrypt/decrypt roundtrip', () {
+    const original = 'secret message';
+    final encrypted = EncryptionService.encrypt(original);
+    expect(encrypted, isNot(equals(original)));
+
+    final decrypted = EncryptionService.decrypt(encrypted);
+    expect(decrypted, equals(original));
+  });
+}

--- a/src/test/message_model_test.dart
+++ b/src/test/message_model_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:chat_startkit_flutter/models/message.dart';
+
+void main() {
+  group('Message model', () {
+    test('serialization/deserialization', () {
+      final message = Message(
+        id: '1',
+        content: 'hello',
+        timestamp: DateTime.parse('2023-01-01T12:00:00.000Z'),
+      );
+      final json = message.toJson();
+      expect(json['id'], '1');
+      expect(json['content'], 'hello');
+      expect(json['timestamp'], '2023-01-01T12:00:00.000Z');
+
+      final fromJson = Message.fromJson(json);
+      expect(fromJson.id, message.id);
+      expect(fromJson.content, message.content);
+      expect(fromJson.timestamp, message.timestamp);
+    });
+
+    test('encodeList/decodeList', () {
+      final messages = [
+        Message(id: '1', content: 'A', timestamp: DateTime.utc(2023, 1, 1)),
+        Message(id: '2', content: 'B', timestamp: DateTime.utc(2023, 1, 2)),
+      ];
+      final encoded = Message.encodeList(messages);
+      final decoded = Message.decodeList(encoded);
+      expect(decoded.length, 2);
+      expect(decoded[0].id, messages[0].id);
+      expect(decoded[1].content, messages[1].content);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add basic unit tests for `Message` model
- add roundtrip test for `EncryptionService`
- update TASK list

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684323485498832fa0d834876d4e6236