### PR TITLE
Enhance WebSocket reliability

### DIFF
--- a/src/lib/bloc/message_event.dart
+++ b/src/lib/bloc/message_event.dart
@@ -34,3 +34,7 @@ class _ErrorReceived extends MessageEvent {
   @override
   List<Object?> get props => [error];
 }
+
+class ReconnectWebSocket extends MessageEvent {
+  const ReconnectWebSocket();
+}

--- a/src/lib/bloc/message_state.dart
+++ b/src/lib/bloc/message_state.dart
@@ -3,16 +3,26 @@ part of 'message_bloc.dart';
 class MessageState extends Equatable {
   final List<Message> messages;
   final String? error;
+  final bool isConnecting;
 
-  const MessageState({this.messages = const [], this.error});
+  const MessageState({
+    this.messages = const [],
+    this.error,
+    this.isConnecting = false,
+  });
 
-  MessageState copyWith({List<Message>? messages, String? error}) {
+  MessageState copyWith({
+    List<Message>? messages,
+    String? error,
+    bool? isConnecting,
+  }) {
     return MessageState(
       messages: messages ?? this.messages,
       error: error,
+      isConnecting: isConnecting ?? this.isConnecting,
     );
   }
 
   @override
-  List<Object?> get props => [messages, error];
+  List<Object?> get props => [messages, error, isConnecting];
 }


### PR DESCRIPTION
## Summary
- track connection status in `MessageState`
- trigger reconnect events and update BLoC
- show a progress indicator when reconnecting
- reconnect WebSocket when app resumes

## Testing
- `flutter --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_684330401d3c832f89afbb8fb4f690ea